### PR TITLE
Test with the lowest dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,34 +13,31 @@ cache:
     - $HOME/.composer/cache/files
 
 env:
-  - SYMFONY_VERSION=2.7.*
+  - SYMFONY_VERSION=2.8.*
 
 matrix:
-  allow_failures:
-    - env: SYMFONY_VERSION=dev-master
-    - php: hhvm
   include:
-    - php: 5.6
-      env: SYMFONY_VERSION=2.7.* SYMFONY_DEPRECATIONS_HELPER=weak
-    - php: 5.6
-      env: SYMFONY_VERSION=2.8.*
-    - php: 5.6
-      env: SYMFONY_VERSION=3.0.*
-  allow_failures:
-    - env: SYMFONY_VERSION=2.8.*
-    - env: SYMFONY_VERSION=3.0.*
+    - php: 7.0
+      env: DEPS=dev SYMFONY_VERSION=3.1.*
+    - php: 5.5
+      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
+    - php: 7.0
+      env: DEPS=dev COMPOSER_FLAGS="--prefer-stable" SYMFONY_VERSION=3.0.*
   fast_finish: true
 
 before_install:
+  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
+  - phpenv config-rm xdebug.ini || true
   - composer self-update
-  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
+  - if [ "$DEPS" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/symfony:${SYMFONY_VERSION} --no-update; fi
 
-install: composer require symfony/symfony:${SYMFONY_VERSION} --prefer-dist
+install: composer update --prefer-dist $COMPOSER_FLAGS
 
 before_script: vendor/symfony-cmf/testing/bin/travis/phpcr_odm_doctrine_dbal.sh
 
 script:
-  - phpunit --coverage-text
+  - phpunit
   - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then ./vendor/symfony-cmf/testing/bin/server & fi
   - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then ./vendor/bin/behat; fi
 

--- a/composer.json
+++ b/composer.json
@@ -11,19 +11,20 @@
     ],
     "require": {
         "php": "^5.5.6|^7.0",
+        "symfony/framework-bundle": "^2.8|^3.0",
         "symfony-cmf/resource-bundle": "^1.0",
         "puli/repository": "@beta",
         "jms/serializer-bundle": "1.*"
     },
     "require-dev": {
-        "symfony-cmf/testing": "^1.3",
-        "doctrine/phpcr-odm": "^1.3",
+        "symfony-cmf/testing": "^1.3|^2.0",
+        "doctrine/phpcr-odm": "^1.3|^2.0",
         "behat/behat": "^3.0",
-        "behat/web-api-extension" : "1.*",
-        "behat/symfony2-extension": "2.*@dev",
-        "matthiasnoback/symfony-dependency-injection-test": "~0.1",
-        "matthiasnoback/symfony-config-test": "~0.1",
-        "sonata-project/doctrine-phpcr-admin-bundle": "^1.2"
+        "behat/web-api-extension" : "^1.0",
+        "behat/symfony2-extension": "^2.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^1.0",
+        "matthiasnoback/symfony-config-test": "^2.0",
+        "sonata-project/doctrine-phpcr-admin-bundle": "^1.2|^2.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
We should remove WebApiTest imo, as the bundle itself is capable of 5.3.3 (afaics), so we have to test against 5.3.3 and not against 5.4.
