### PR TITLE
Added node name

### DIFF
--- a/Enhancer/SonataAdminEnhancer.php
+++ b/Enhancer/SonataAdminEnhancer.php
@@ -76,6 +76,7 @@ class SonataAdminEnhancer implements EnhancerInterface
             $links[$routeRole] = $url;
         }
 
+        $data['label'] = $admin->toString($object);
         $data['sonata_label'] = $admin->getLabel();
         $data['sonata_links'] = $links;
 

--- a/Serializer/Jms/Handler/ResourceHandler.php
+++ b/Serializer/Jms/Handler/ResourceHandler.php
@@ -15,6 +15,7 @@ use JMS\Serializer\GraphNavigator;
 use JMS\Serializer\JsonSerializationVisitor;
 use JMS\Serializer\Context;
 use PHPCR\NodeInterface;
+use PHPCR\Util\PathHelper;
 use Puli\Repository\Api\Resource\Resource;
 use Symfony\Cmf\Component\Resource\RepositoryRegistryInterface;
 use Symfony\Cmf\Bundle\ResourceRestBundle\Registry\PayloadAliasRegistry;
@@ -85,6 +86,7 @@ class ResourceHandler implements SubscribingHandlerInterface
         }
 
         $data['path'] = $resource->getPath();
+        $data['label'] = $data['node_name'] = PathHelper::getNodeName($data['path']);
         $data['repository_path'] = $resource->getRepositoryPath();
 
         $enhancers = $this->enhancerRegistry->getEnhancers($repositoryAlias);

--- a/Tests/Features/resource_api_phpcr.feature
+++ b/Tests/Features/resource_api_phpcr.feature
@@ -34,6 +34,8 @@ Feature: PHPCR resource repository
                 "payload_alias": null,
                 "payload_type": "nt:unstructured",
                 "path": "\/foo",
+                "node_name": "foo",
+                "label": "foo",
                 "repository_path": "\/foo",
                 "children": []
             }

--- a/Tests/Features/resource_api_phpcr_odm.feature
+++ b/Tests/Features/resource_api_phpcr_odm.feature
@@ -35,6 +35,8 @@ Feature: PHPCR-ODM resource repository
                 "payload_alias": "article",
                 "payload_type": "Symfony\\Cmf\\Bundle\\ResourceRestBundle\\Tests\\Resources\\TestBundle\\Document\\Article",
                 "path": "\/foo",
+                "node_name": "foo",
+                "label": "foo",
                 "repository_path": "\/foo",
                 "children": []
             }
@@ -61,6 +63,8 @@ Feature: PHPCR-ODM resource repository
                 "payload_alias": "article",
                 "payload_type": "Symfony\\Cmf\\Bundle\\ResourceRestBundle\\Tests\\Resources\\TestBundle\\Document\\Article",
                 "path": "\/foo",
+                "node_name": "foo",
+                "label": "foo",
                 "repository_path": "\/foo",
                 "children": {
                     "bar": {
@@ -69,6 +73,8 @@ Feature: PHPCR-ODM resource repository
                         "payload_alias": "article",
                         "payload_type": "Symfony\\Cmf\\Bundle\\ResourceRestBundle\\Tests\\Resources\\TestBundle\\Document\\Article",
                         "path": "/foo/bar",
+                        "node_name": "bar",
+                        "label": "bar",
                         "repository_path": "/foo/bar",
                         "children": [ ]
                     },
@@ -78,6 +84,8 @@ Feature: PHPCR-ODM resource repository
                         "payload_alias": "article",
                         "payload_type": "Symfony\\Cmf\\Bundle\\ResourceRestBundle\\Tests\\Resources\\TestBundle\\Document\\Article",
                         "path": "/foo/boo",
+                        "node_name": "boo",
+                        "label": "boo",
                         "repository_path": "/foo/boo",
                         "children": [ ]
                     }

--- a/Tests/Unit/Enhancer/SonataAdminEnhancerTest.php
+++ b/Tests/Unit/Enhancer/SonataAdminEnhancerTest.php
@@ -76,6 +76,7 @@ class SonataAdminEnhancerTest extends ProphecyTestCase
 
         $this->admin->getIdParameter()->willReturn('id');
         $this->admin->getLabel()->willReturn('Admin Label');
+        $this->admin->toString($this->payload)->willReturn('Admin');
 
         $result = $this->enhancer->enhance(
             $data,
@@ -83,6 +84,7 @@ class SonataAdminEnhancerTest extends ProphecyTestCase
         );
 
         $this->assertEquals(array(
+            'label' => 'Admin',
             'sonata_label' => 'Admin Label',
             'sonata_links' => array(
                 'edit' => 'http://edit',

--- a/Tests/Unit/Serializer/Jms/Handler/ResourceHandlerTest.php
+++ b/Tests/Unit/Serializer/Jms/Handler/ResourceHandlerTest.php
@@ -76,6 +76,8 @@ class ResourceHandlerTest extends ProphecyTestCase
             'payload_alias' => 'alias',
             'payload_type' => 'payload_type',
             'path' => '/path/to',
+            'node_name' => 'to',
+            'label' => 'to',
             'repository_path' => '/repository/path',
             'children' => array(
                 array(
@@ -84,6 +86,8 @@ class ResourceHandlerTest extends ProphecyTestCase
                     'payload_alias' => 'alias',
                     'payload_type' => 'payload_type',
                     'path' => '/path/to/child',
+                    'label' => 'child',
+                    'node_name' => 'child',
                     'repository_path' => '/child/repository/path',
                     'children' => array(),
                 ),


### PR DESCRIPTION
This is used as the name of the nodes in the TreeBrowserBundle. When the sonata enhancer is enabled, it uses the toString method to get a much better node name.
