### PR TITLE
Updated stable 1.0 of jms/serializer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.3.9",
         "symfony-cmf/resource-bundle": "~1.0",
-        "jms/serializer-bundle": "~0.13"
+        "jms/serializer-bundle": "~1.0"
     },
     "require-dev": {
         "symfony-cmf/testing": "~1.1",


### PR DESCRIPTION
It seems that the [1.0 version](https://github.com/schmittjoh/serializer/releases) of JMS serializer was released in July. I think it makes sense for this to now be the minimal version. /cc @WouterJ 

Fixes: #21
