### PR TITLE
Point to jms_serializer rather than serializer

### DIFF
--- a/src/Resources/config/resource-rest.xml
+++ b/src/Resources/config/resource-rest.xml
@@ -7,7 +7,7 @@
     <services>
 
         <service id="cmf_resource_rest.controller.resource" class="Symfony\Cmf\Bundle\ResourceRestBundle\Controller\ResourceController">
-            <argument type="service" id="serializer" />
+            <argument type="service" id="jms_serializer" />
             <argument type="service" id="cmf_resource.registry" />
             <argument type="service" id="cmf_resource_rest.serializer.jms.handler.resource" />
             <argument type="service" id="security.authorization_checker" on-invalid="ignore" />


### PR DESCRIPTION
If one is running two serializers in a symfony project (JMS and the default one), then serializer will most likely not point to the JMS one.

That's why it would be better to point it to jms_serializer in this config rather than using the alias.