### PR TITLE
use caret operator for symfony-cmf/resource-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^5.6|^7.0",
-        "symfony-cmf/resource-bundle": "1.0.*",
+        "symfony-cmf/resource-bundle": "^1.0",
         "jms/serializer-bundle": "^1.0 | ^2.0",
         "symfony/translation": "^2.8|^3.0"
     },


### PR DESCRIPTION
As `symfony-cmf/resource-bundle` follows semver, we can safely use the caret operator.