### PR TITLE
Allow jms/serializer-bundle 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_install:
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/symfony:${SYMFONY_VERSION} --no-update; fi
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
 
-install: travis_wait composer update --prefer-dist $COMPOSER_FLAGS
+install: COMPOSER_MEMORY_LIMIT=-1 travis_wait composer update --prefer-dist $COMPOSER_FLAGS
 
 script:
   - if [ "${TEST_INSTALLATION}" == true ]; then make test_installation; else make test; fi

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^7.1",
         "symfony-cmf/resource-bundle": "^1.0",
-        "jms/serializer-bundle": "^1.0 | ^2.0",
+        "jms/serializer-bundle": "^1.0 | ^2.0 | ^3.0",
         "symfony/translation": "^2.8 || ^3.3 || ^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.1
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

Hello, I'm not able to test if it works as I still can't update my project to `jms/serializer-bundle` v3, but here is a PR. I made it because I can't update many libs such as `sonata-project/admin-bundle` which require higher versions of `jms/*`.