### PR TITLE
Increased JMS Serialization to 2+ version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^7.2",
         "symfony-cmf/resource-bundle": "^1.0",
-        "jms/serializer-bundle": "^2.0 | ^3.0",
+        "jms/serializer-bundle": "^3.0",
         "symfony/translation": "^2.8 || ^3.3 || ^4.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,13 @@
     "require": {
         "php": "^7.2",
         "symfony-cmf/resource-bundle": "^1.0",
-        "jms/serializer-bundle": "^1.0 | ^2.0 | ^3.0",
+        "jms/serializer-bundle": "^2.0 | ^3.0",
         "symfony/translation": "^2.8 || ^3.3 || ^4.0"
     },
     "require-dev": {
         "symfony-cmf/testing": "^2.1@dev",
         "symfony/phpunit-bridge": "^5",
         "doctrine/phpcr-odm": "^1.4|^2.0",
-        "jms/serializer": "^1.2",
         "behat/behat": "^3.0.6",
         "imbo/behat-api-extension": "^2.1",
         "matthiasnoback/symfony-dependency-injection-test": "^4",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^7.2",
         "symfony-cmf/resource-bundle": "^1.0",
-        "jms/serializer-bundle": "^3.0",
+        "jms/serializer-bundle": "^2.0 || ^3.0",
         "symfony/translation": "^2.8 || ^3.3 || ^4.0"
     },
     "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,4 +20,9 @@
             </exclude>
         </whitelist>
     </filter>
+
+    <php>
+        <env name="SYMFONY_PHPUNIT_VERSION" value="8.5"/>
+    </php>
+    
 </phpunit>

--- a/src/Serializer/Jms/Handler/PhpcrNodeHandler.php
+++ b/src/Serializer/Jms/Handler/PhpcrNodeHandler.php
@@ -14,7 +14,7 @@ namespace Symfony\Cmf\Bundle\ResourceRestBundle\Serializer\Jms\Handler;
 use JMS\Serializer\Context;
 use JMS\Serializer\GraphNavigator;
 use JMS\Serializer\Handler\SubscribingHandlerInterface;
-use JMS\Serializer\JsonSerializationVisitor;
+use JMS\Serializer\Visitor\SerializationVisitorInterface;
 use PHPCR\NodeInterface;
 
 /**
@@ -40,7 +40,7 @@ class PhpcrNodeHandler implements SubscribingHandlerInterface
      * @param NodeInterface $nodeInterface
      */
     public function serializePhpcrNode(
-        JsonSerializationVisitor $visitor,
+        SerializationVisitorInterface $visitor,
         NodeInterface $node,
         array $type,
         Context $context

--- a/src/Serializer/Jms/Handler/ResourceHandler.php
+++ b/src/Serializer/Jms/Handler/ResourceHandler.php
@@ -14,7 +14,7 @@ namespace Symfony\Cmf\Bundle\ResourceRestBundle\Serializer\Jms\Handler;
 use JMS\Serializer\Context;
 use JMS\Serializer\GraphNavigator;
 use JMS\Serializer\Handler\SubscribingHandlerInterface;
-use JMS\Serializer\JsonSerializationVisitor;
+use JMS\Serializer\Visitor\SerializationVisitorInterface;
 use PHPCR\NodeInterface;
 use PHPCR\Util\PathHelper;
 use Symfony\Cmf\Bundle\ResourceRestBundle\Registry\PayloadAliasRegistry;
@@ -70,13 +70,13 @@ class ResourceHandler implements SubscribingHandlerInterface
      * @param NodeInterface $resourceInterface
      */
     public function serializeResource(
-        JsonSerializationVisitor $visitor,
+        SerializationVisitorInterface $visitor,
         PuliResource $resource,
         array $type,
         Context $context
     ) {
         $data = $this->doSerializeResource($resource);
-        $context->accept($data);
+        $context->getNavigator()->accept($data);
     }
 
     public function setMaxDepth($maxDepth)

--- a/tests/Unit/Serializer/Jms/Handler/PhpcrNodeHandlerTest.php
+++ b/tests/Unit/Serializer/Jms/Handler/PhpcrNodeHandlerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Cmf\Bundle\ResourceRestBundle\Tests\Unit\Serializer\Jms\Handler;
 
+use JMS\Serializer\Visitor\SerializationVisitorInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Cmf\Bundle\ResourceRestBundle\Serializer\Jms\Handler\PhpcrNodeHandler;
 
@@ -29,7 +30,7 @@ class PhpcrNodeHandlerTest extends TestCase
         $this->node = $this->prophesize('PHPCR\NodeInterface');
         $this->property1 = $this->prophesize('PHPCR\PropertyInterface');
         $this->property2 = $this->prophesize('PHPCR\PropertyInterface');
-        $this->visitor = $this->prophesize('JMS\Serializer\JsonSerializationVisitor');
+        $this->visitor = $this->prophesize(SerializationVisitorInterface::class);
         $this->context = $this->prophesize('JMS\Serializer\Context');
         $this->handler = new PhpcrNodeHandler();
     }

--- a/tests/Unit/Serializer/Jms/Handler/ResourceHandlerTest.php
+++ b/tests/Unit/Serializer/Jms/Handler/ResourceHandlerTest.php
@@ -12,7 +12,8 @@
 namespace Symfony\Cmf\Bundle\ResourceRestBundle\Tests\Unit\Serializer\Jms\Handler;
 
 use JMS\Serializer\Context;
-use JMS\Serializer\JsonSerializationVisitor;
+use JMS\Serializer\GraphNavigatorInterface;
+use JMS\Serializer\Visitor\SerializationVisitorInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Symfony\Cmf\Bundle\ResourceRestBundle\Registry\PayloadAliasRegistry;
@@ -45,16 +46,19 @@ class ResourceHandlerTest extends TestCase
 
     private $description;
 
+    private $navigator;
+
     protected function setUp(): void
     {
         $this->repositoryRegistry = $this->prophesize(RepositoryRegistryInterface::class);
         $this->payloadAliasRegistry = $this->prophesize(PayloadAliasRegistry::class);
-        $this->visitor = $this->prophesize(JsonSerializationVisitor::class);
+        $this->visitor = $this->prophesize(SerializationVisitorInterface::class);
         $this->resource = $this->prophesize(CmfResource::class);
         $this->childResource = $this->prophesize(CmfResource::class);
 
         $this->repository = $this->prophesize(ResourceRepository::class);
         $this->context = $this->prophesize(Context::class);
+        $this->navigator = $this->prophesize(GraphNavigatorInterface::class);
 
         $this->description = $this->prophesize(Description::class);
         $this->description->all()->willReturn([]);
@@ -118,7 +122,8 @@ class ResourceHandlerTest extends TestCase
             'descriptors' => [],
         ];
 
-        $this->context->accept($expected)->shouldBeCalled();
+        $this->context->getNavigator()->willReturn($this->navigator);
+        $this->navigator->accept($expected)->willReturn($this->context);
 
         $this->handler->serializeResource(
             $this->visitor->reveal(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | https://github.com/symfony-cmf/resource-rest-bundle/issues/74
| License       | MIT

Drop support JMS Serializer version 1.
Fixed exception with unknown function in the version above 1. https://github.com/schmittjoh/serializer/blob/1.14.1/src/JMS/Serializer/Context.php#L71
That is we can now use this bundle along with sonata-core bundle that requires JMS Serializer version 2+, but we have 1.
