### PR TITLE
Serializer - Fixed missing return in ResourceHandler

### DIFF
--- a/src/Serializer/Jms/Handler/ResourceHandler.php
+++ b/src/Serializer/Jms/Handler/ResourceHandler.php
@@ -78,7 +78,7 @@ class ResourceHandler implements SubscribingHandlerInterface
         $data = $this->doSerializeResource($resource);
         $context->getNavigator()->accept($data);
 
-	return $data;
+        return $data;
     }
 
     public function setMaxDepth($maxDepth)

--- a/src/Serializer/Jms/Handler/ResourceHandler.php
+++ b/src/Serializer/Jms/Handler/ResourceHandler.php
@@ -77,6 +77,8 @@ class ResourceHandler implements SubscribingHandlerInterface
     ) {
         $data = $this->doSerializeResource($resource);
         $context->getNavigator()->accept($data);
+
+	return $data;
     }
 
     public function setMaxDepth($maxDepth)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master/1.2?"
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A (need to create an issue first?)
| License       | MIT
| Doc PR        | N/A

See https://github.com/schmittjoh/serializer/blob/master/src/GraphNavigator/SerializationGraphNavigator.php#L205

JMS Serializer now needs a returned value from the callback. The PhpcrNodeHandler class is still working because it is returning an array. ResourceHandler does not.

